### PR TITLE
Fix twine upload failing when version exists

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -44,9 +44,9 @@ steps:
     - name: python-modules
       path: /usr/local/lib/python3.7/site-packages
   commands:
-    - pip install twine
+    - pip install twine wheel
     - python setup.py sdist bdist_wheel
-    - twine upload dist/* 2>twine_error || grep "This filename has already been used, use a different version." twine_error
+    - twine upload --skip-existing dist/*
   when:
     branch: master
     event: push

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     package_data={
         'beautifurl': ['dictionaries/*']
     },
-    version='0.0.1',
+    version='0.0.2',
     license='MIT',  # example license
     description='Generates beautiful urls similar to Gfycat.',
     long_description=README,


### PR DESCRIPTION
The current drone build fails when the version already exists
in PyPi.  This is due to a difference in response between the
test and production versions of pypi.

Version is updated because this is the current latest version on production pypi.