### PR TITLE
Remove camel case option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ BeautifURL can be installed from pip
     >>> beautifurl.get_random_url('aaA')
     'BeautifulAdventurousGiraffe'
 
-    >>> beautifurl.get_random_url('aaA', camelCase=False)
-    'foolishjoyoussquirrel'
-
     >>> beautifurl.count_permutations('aaA')
     10492819
 

--- a/beautifurl/beautifurl.py
+++ b/beautifurl/beautifurl.py
@@ -26,14 +26,12 @@ class Beautifurl:
                               self._dict_path + " with key " + key)
         return self._cache[key]
 
-    def get_random_url(self, formt, camel_case=True):
+    def get_random_url(self, formt):
         """
         Generate a url based on a given format.
 
         Args:
             formt: The format of the url.
-            camelCase (optional): Should the url use camel case.
-                (Default: True)
 
         Returns:
             The generated url.
@@ -54,8 +52,6 @@ class Beautifurl:
             selected.append(options[choice])
             # Swap choice with last selectable to ensure unique
             options[choice], options[swap] = options[swap], options[choice]
-        if not camel_case:
-            selected = [x.lower() for x in selected]
         return ''.join(selected)
 
     def count_permutations(self, formt):
@@ -75,7 +71,7 @@ class Beautifurl:
             count = count * len(self._get_dictionary(key))
         return count
 
-    def get_permutations(self, formt, shuffle=False, camel_case=True):
+    def get_permutations(self, formt, shuffle=False):
         """
         Get all permutations for a given format
 
@@ -83,8 +79,6 @@ class Beautifurl:
             formt: The format of the url.
             shuffled (optional): Should the permutations be generated in a
                 random order.  (Default: False)
-            camel_case (optional): Should the url use camel case.
-                (Default: True)
 
         Returns:
             An iterator that yields the permutations
@@ -94,20 +88,17 @@ class Beautifurl:
             lists = [list(x) for x in lists]
             for lst in lists:
                 random.shuffle(lst)
-        return PermutationIterator(itertools.product(*lists), camel_case)
+        return PermutationIterator(itertools.product(*lists))
 
 class PermutationIterator:
 
-    def __init__(self, iterator, camel_case):
+    def __init__(self, iterator):
         self.iterator = iterator
-        self.camel_case = camel_case
 
     def __next__(self, product=None):
         # Allow python2 next to use this function.
         if product is None:
             product = self.iterator.__next__()
-        if not self.camel_case:
-            product = [x.lower() for x in product]
         return ''.join(product)
 
     # Python 2 support

--- a/beautifurl/test_beautifurl.py
+++ b/beautifurl/test_beautifurl.py
@@ -41,9 +41,7 @@ def test_get_random_url():
 def test_get_random_url_key_position():
     beatifurl = Beautifurl(dictionary_path='test/dictionaries')
     url = beatifurl.get_random_url('abc')
-    assert url[:5] == 'Hello'
-    assert url[5:10] == 'World'
-    assert url[10:] == 'Test'
+    assert url == 'HelloWorldTest'
 
 def test_count_permutations():
     beatifurl = Beautifurl(dictionary_path='test/dictionaries')
@@ -80,27 +78,9 @@ def test_get_permutations_shuffle():
     assert expected == []
     assert out_of_order
 
-def test_get_random_url_no_camel_case():
-    beatifurl = Beautifurl(dictionary_path='test/dictionaries')
-    url = beatifurl.get_random_url('abc', camel_case=False)
-    assert url[:5] == 'hello'
-    assert url[5:10] == 'world'
-    assert url[10:] == 'test'
-
-def test_get_permutations_no_camel_case():
-    beatifurl = Beautifurl(dictionary_path='test/dictionaries')
-    expected = itertools.product(['hello', 'world', 'test'],
-                                 ['hello'],
-                                 ['hello', 'world', 'test'])
-    expected = [''.join(x) for x in expected]
-    actual = beatifurl.get_permutations('tat', camel_case=False)
-    assert is_iterator(actual)
-    for (x, y) in zip(actual, expected):
-        assert x == y
-
 def test_get_permutations_elements_are_string():
     beatifurl = Beautifurl(dictionary_path='test/dictionaries')
-    actual = beatifurl.get_permutations('tat', camel_case=True)
+    actual = beatifurl.get_permutations('tat')
     for element in actual:
         assert element.__class__ == str
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     package_data={
         'beautifurl': ['dictionaries/*']
     },
-    version='0.0.2',
+    version='0.1.0',
     license='MIT',  # example license
     description='Generates beautiful urls similar to Gfycat.',
     long_description=README,


### PR DESCRIPTION
The camel_case=False option added to most methods is easily implemented
by users by calling .tolower() after generating a string.  As such it
has been removed from the API.