### PR TITLE
Improve shuffling of permutations

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -324,6 +324,7 @@ function-naming-style=snake_case
 good-names=i,
            j,
            k,
+           n,
            x,
            y,
            z,

--- a/README.md
+++ b/README.md
@@ -17,16 +17,18 @@ BeautifURL can be installed from pip
     'BeautifulAdventurousGiraffe'
 
     >>> beautifurl.count_permutations('aaA')
-    10492819
+    9150136
 
     >>> for url in beautifurl.get_permutations('aaA', shuffle=True):
     ...     print(url)
-    ... 
-    ScaryJollyEchidna
-    ScaryJollyPig
-    ScaryJollyFlamingo
-    ScaryJollyNewt
-    ScaryJollyEmu
+    ...
+
+    GloriousDeterminedPeafowl
+    NiceSuccessfulJackal
+    DepressedStupidPartridge
+    StormyStrangeGiraffe
+    AngryPleasantMonkey
+    ...
 
 ### Url format
 

--- a/beautifurl/beautifurl.py
+++ b/beautifurl/beautifurl.py
@@ -1,6 +1,29 @@
 import itertools
+import operator
 import os
 import random
+
+from functools import reduce
+
+from shuffled import Shuffled
+
+def get_nth_product(n, elements):
+    """
+    Get the nth product of a list without calculating any other products.
+    The order is the same as itertools.product(x).
+
+    Args:
+        n: The number product to generate
+        elements: The lists to generate the product from
+
+    Returns:
+        The nth product of elements
+    """
+    length = len(elements)
+    demoninators = [reduce(operator.mul, (map(len, elements[x + 1:])), 1)
+                    for x in range(length)]
+    return [elements[x][(n // demoninators[x]) % len(elements[x])]
+            for x in range(length)]
 
 class Beautifurl:
 
@@ -85,25 +108,12 @@ class Beautifurl:
         """
         lists = [self._get_dictionary(x) for x in formt]
         if shuffle:
-            lists = [list(x) for x in lists]
-            for lst in lists:
-                random.shuffle(lst)
-        return PermutationIterator(itertools.product(*lists))
-
-class PermutationIterator:
-
-    def __init__(self, iterator):
-        self.iterator = iterator
-
-    def __next__(self, product=None):
-        # Allow python2 next to use this function.
-        if product is None:
-            product = self.iterator.__next__()
-        return ''.join(product)
-
-    # Python 2 support
-    def next(self):
-        return self.__next__(product=self.iterator.next())
-
-    def __iter__(self):
-        return self
+            iterator_length = self.count_permutations(formt)
+            return map(
+                lambda x: ''.join(get_nth_product(x, lists)),
+                Shuffled(iterator_length)
+            )
+        return map(
+            ''.join,
+            itertools.product(*lists)
+        )

--- a/beautifurl/test_beautifurl.py
+++ b/beautifurl/test_beautifurl.py
@@ -1,8 +1,10 @@
 import os
-
+import re
 import itertools
 
-from .beautifurl import Beautifurl
+from collections import defaultdict
+
+from .beautifurl import Beautifurl, get_nth_product
 
 def test_default_dictonary_path():
     beautifurl = Beautifurl()
@@ -21,51 +23,51 @@ def test_overwrite_dictionary_path_rel():
     assert beautifurl._dict_path[0] == '/'
 
 def test_load_dictionary_from_key():
-    beatifurl = Beautifurl(dictionary_path='test/dictionaries')
+    beautifurl = Beautifurl(dictionary_path='test/dictionaries')
     key = 't'
-    words = beatifurl._get_dictionary(key)
+    words = beautifurl._get_dictionary(key)
     assert len(words) == 3
     # Ensure reads from cache
-    beatifurl._dict_path = '/dev/null'
-    words = beatifurl._get_dictionary(key)
+    beautifurl._dict_path = '/dev/null'
+    words = beautifurl._get_dictionary(key)
     assert len(words) == 3
 
 def test_get_random_url():
-    beatifurl = Beautifurl(dictionary_path='test/dictionaries')
-    url = beatifurl.get_random_url('ttt')
+    beautifurl = Beautifurl(dictionary_path='test/dictionaries')
+    url = beautifurl.get_random_url('ttt')
     assert 'Hello' in url
     assert 'World' in url
     assert 'Test' in url
     assert '\n' not in url
 
 def test_get_random_url_key_position():
-    beatifurl = Beautifurl(dictionary_path='test/dictionaries')
-    url = beatifurl.get_random_url('abc')
+    beautifurl = Beautifurl(dictionary_path='test/dictionaries')
+    url = beautifurl.get_random_url('abc')
     assert url == 'HelloWorldTest'
 
 def test_count_permutations():
-    beatifurl = Beautifurl(dictionary_path='test/dictionaries')
-    perms = beatifurl.count_permutations('tat')
+    beautifurl = Beautifurl(dictionary_path='test/dictionaries')
+    perms = beautifurl.count_permutations('tat')
     assert perms == 3 * 1 * 3
 
 def test_get_permutations():
-    beatifurl = Beautifurl(dictionary_path='test/dictionaries')
+    beautifurl = Beautifurl(dictionary_path='test/dictionaries')
     expected = itertools.product(['Hello', 'World', 'Test'],
                                  ['Hello'],
                                  ['Hello', 'World', 'Test'])
     expected = [''.join(x) for x in expected]
-    actual = beatifurl.get_permutations('tat')
+    actual = beautifurl.get_permutations('tat')
     assert is_iterator(actual)
     for (x, y) in zip(actual, expected):
         assert x == y
 
 def test_get_permutations_shuffle():
-    beatifurl = Beautifurl(dictionary_path='test/dictionaries')
+    beautifurl = Beautifurl(dictionary_path='test/dictionaries')
     expected = itertools.product(['Hello', 'World', 'Test'],
                                  ['Hello'],
                                  ['Hello', 'World', 'Test'])
     expected = [''.join(x) for x in expected]
-    actual = beatifurl.get_permutations('tat', shuffle=True)
+    actual = beautifurl.get_permutations('tat', shuffle=True)
     assert is_iterator(actual)
     # TODO make test deterministic.
     # Can sometimes fail as shuffled list may be the same as
@@ -78,11 +80,59 @@ def test_get_permutations_shuffle():
     assert expected == []
     assert out_of_order
 
+def test_get_permutations_with_shuffle_keeps_map_order():
+    test_key = 'tat'
+
+    beautifurl = Beautifurl(dictionary_path='test/dictionaries')
+    shuffled = beautifurl.get_permutations(test_key, shuffle=True)
+    for url in shuffled:
+        # Divide into words by capital letter
+        split_url = re.findall('[A-Z][a-z]+', url)
+        for (word, key) in zip(split_url, test_key):
+            assert word in beautifurl._cache[key]
+
+def test_get_permutations_with_shuffle_is_suffiently_shuffled():
+    """
+    Catches the case where urls are shuffled one index after the other
+
+    e.g
+    LightCalmSloth
+    LightCalmFerret
+    LightCalmToad
+    ...
+    """
+    test_key = 'aaA' # Use the real dictionaries as the tests ones are too small
+    min_count = 70 # If there are less than 70 unique words per position then fail
+
+    beautifurl = Beautifurl()
+    shuffled = beautifurl.get_permutations(test_key, shuffle=True)
+    urls_as_lists = map(lambda x: re.findall('[A-Z][a-z]+', x), itertools.islice(shuffled, 100))
+    words_by_position = defaultdict(list)
+    for url in urls_as_lists:
+        for (i, word) in enumerate(url):
+            words_by_position[i].append(word)
+
+    for i in range(len(test_key)): # Test dictionary in order
+        count = len(set(words_by_position[i]))
+        assert count > min_count
+
 def test_get_permutations_elements_are_string():
-    beatifurl = Beautifurl(dictionary_path='test/dictionaries')
-    actual = beatifurl.get_permutations('tat')
+    beautifurl = Beautifurl(dictionary_path='test/dictionaries')
+    actual = beautifurl.get_permutations('tat')
     for element in actual:
         assert element.__class__ == str
+
+def test_get_nth_product_with_three_elements():
+    elements = [list(range(x + 1)) for x in range(3)]
+
+    for (i, element) in enumerate(itertools.product(*elements)):
+        assert get_nth_product(i, elements) == list(element)
+
+def test_get_nth_product_with_four_elements():
+    elements = [list(range(x + 1)) for x in range(4)]
+
+    for (i, element) in enumerate(itertools.product(*elements)):
+        assert get_nth_product(i, elements) == list(element)
 
 def is_iterator(obj):
     # Checks if object is an iterator.  Does not return true for list.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,11 @@
 appdirs==1.4.3
+asn1crypto==0.24.0
+cffi==1.11.5
+cryptography==2.5
 packaging==16.8
 py==1.4.33
+pycparser==2.19
 pyparsing==2.2.0
 pytest==3.0.7
+shuffled==0.2
 six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ setup(
     package_data={
         'beautifurl': ['dictionaries/*']
     },
-    version='0.1.0',
-    license='MIT',  # example license
+    version='0.1.1',
+    license='MIT',
     description='Generates beautiful urls similar to Gfycat.',
     long_description=README,
     url='https://github.com/hintofbasil/Python-Beautifurl',
@@ -22,7 +22,7 @@ setup(
     author_email='crabbybearnose@shadowmail.co.uk',
     test_suite="test",
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
+        'Development Status :: 4 - Beta',
         'License :: OSI Approved :: MIT License',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',


### PR DESCRIPTION
The shuffled version of get_permutations did not shuffle the data
sufficiently.  It simply shuffled the lists and passed them into
itertools.product producing a prodictable ordering.
To improve this a method was created to get the nth product and used
alongside a lazy shuffled range implementation to create a lazy
generator which produces a well shuffled output.