### PR TITLE
Add install_requires argument to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,10 @@ setup(
     package_data={
         'beautifurl': ['dictionaries/*']
     },
-    version='0.1.1',
+    install_requires=[
+        'shuffled>=0.2'
+    ]
+    version='0.1.2',
     license='MIT',
     description='Generates beautiful urls similar to Gfycat.',
     long_description=README,


### PR DESCRIPTION
The library now depends on another package and so this must be
added to setup.py to ensure the dependency is installed
alongside this package.